### PR TITLE
Weapon Restrict per map

### DIFF
--- a/src/config/config.cs
+++ b/src/config/config.cs
@@ -21,6 +21,10 @@ public class Config : BasePluginConfig
         public string? WorldModel { get; set; }
         public List<string> AdminFlagsToIgnoreBlockUsing { get; set; } = [];
         public Dictionary<int, int> WeaponQuota { get; set; } = [];
+
+        // 🔹 Novo polje za restrikcije po mapama
+        public Dictionary<string, Dictionary<int, int>> MapSpecificQuota { get; set; } = [];
+
         public string? Damage { get; set; }
     }
 }

--- a/src/cs2-advanced-weapon-system.cs
+++ b/src/cs2-advanced-weapon-system.cs
@@ -14,7 +14,7 @@ namespace AdvancedWeaponSystem;
 public class AdvancedWeaponSystem : BasePlugin, IPluginConfig<Config>
 {
     public override string ModuleName => "Advanced Weapon System";
-    public override string ModuleVersion => "1.8";
+    public override string ModuleVersion => "1.9";
     public override string ModuleAuthor => "schwarper";
 
     public Config Config { get; set; } = new Config();
@@ -188,4 +188,5 @@ public class AdvancedWeaponSystem : BasePlugin, IPluginConfig<Config>
         return HookResult.Handled;
     }
 }
+
 


### PR DESCRIPTION
This PR introduces a new feature that allows server admins to restrict specific weapons on a per-map basis.

Changes included:

Added configuration options to set weapon restrictions for each map.
All restrictions per-map are in config file


Benefits:

Greater flexibility for server customization.

Allows balanced gameplay by limiting certain weapons on specific maps.